### PR TITLE
Fix wrong-type-argument on nil secret reference

### DIFF
--- a/auth-source-1password.el
+++ b/auth-source-1password.el
@@ -52,14 +52,15 @@ by host and user."
   "Searche 1password for the specified user and host.
 SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
   (if (executable-find auth-source-1password-executable)
-      (let ((got-secret
-             (string-trim
-              (shell-command-to-string
-               (format "%s read op://%s"
-                       auth-source-1password-executable
-                       (shell-quote-argument (funcall auth-source-1password-construct-secret-reference backend type host user port)))))))
-        (list (list :user user
-                    :secret got-secret)))
+      (when-let ((secret-reference (funcall auth-source-1password-construct-secret-reference backend type host user port)))
+        (let ((got-secret
+               (string-trim
+                (shell-command-to-string
+                 (format "%s read op://%s"
+                         auth-source-1password-executable
+                         (shell-quote-argument secret-reference))))))
+          (list (list :user user
+                      :secret got-secret))))
     ;; If not executable was found, return nil and show a warning
     (warn "`auth-source-1password': Could not find executable '%s' to query 1password" auth-source-1password-executable)))
 


### PR DESCRIPTION
Fixes a wrong-type-argument error from `shell-quote-argument` when `auth-source-1password-construct-secret-reference` returns nil.