### PR TITLE
Honor op's exit status so failed lookups return nil instead of a bogus secret

### DIFF
--- a/auth-source-1password.el
+++ b/auth-source-1password.el
@@ -49,19 +49,46 @@ by host and user."
 (cl-defun auth-source-1password-search (&rest spec
                                            &key backend type host user port
                                            &allow-other-keys)
-  "Searche 1password for the specified user and host.
-SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
-  (if (executable-find auth-source-1password-executable)
-      (let ((got-secret
-             (string-trim
-              (shell-command-to-string
-               (format "%s read op://%s"
-                       auth-source-1password-executable
-                       (shell-quote-argument (funcall auth-source-1password-construct-secret-reference backend type host user port)))))))
-        (list (list :user user
-                    :secret got-secret)))
-    ;; If not executable was found, return nil and show a warning
-    (warn "`auth-source-1password': Could not find executable '%s' to query 1password" auth-source-1password-executable)))
+  "Search 1password for the specified user and host.
+SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source.
+
+Return a list holding a single (:user USER :secret SECRET) plist when the
+reference resolves, or nil when the `op' executable is missing, the reference
+is empty, the lookup fails, or no secret is returned.  Returning nil for an
+unresolved reference lets auth-source fall through to the remaining backends
+instead of handing the caller `op's error output as a bogus secret.  On
+failure `op's output is reported through `auth-source-do-debug', so it is
+visible when `auth-source-debug' is enabled and silent otherwise."
+  (let ((executable (executable-find auth-source-1password-executable))
+        (reference (funcall auth-source-1password-construct-secret-reference
+                            backend type host user port)))
+    (cond
+     ((not executable)
+      ;; If no executable was found, return nil and show a warning.
+      (warn "`auth-source-1password': Could not find executable '%s' to query 1password"
+            auth-source-1password-executable))
+     ;; A custom `auth-source-1password-construct-secret-reference' may return
+     ;; nil (or "") to opt out of this query; skip the `op' call and let other
+     ;; backends answer.
+     ((or (null reference) (string= reference "")) nil)
+     (t
+      (let (output status)
+        (with-temp-buffer
+          ;; `call-process' (unlike `shell-command-to-string') hands back the
+          ;; exit status, so we can tell a resolved reference from an `op'
+          ;; error.  stdout and stderr are mixed into this buffer: on success
+          ;; it holds the secret, on failure `op's diagnostics.
+          (setq status (call-process executable nil t nil
+                                     "read" (concat "op://" reference))
+                output (string-trim (buffer-string))))
+        (if (and (eq status 0) (not (string= output "")))
+            (list (list :user user :secret output))
+          ;; Surface the failure only through auth-source's own debug channel
+          ;; so a routine miss (e.g. a host kept elsewhere) stays quiet.
+          (auth-source-do-debug
+           "auth-source-1password: `op read op://%s' failed (status %s): %s"
+           reference status output)
+          nil))))))
 
 ;;;###autoload
 (defun auth-source-1password-enable ()


### PR DESCRIPTION
## Summary

`auth-source-1password-search` cannot tell a successful lookup from a failed
one, so it returns a non-nil result for **every** query — even when the secret
reference does not resolve. This makes the backend shadow all other
`auth-sources` and hand consumers garbage credentials. This PR checks `op`'s
exit status so a failed lookup returns `nil` and auth-source falls through to
the remaining backends.

> Supersedes #3 — see "Relationship to #3" below.

## The bug

The search function runs `op read` through `shell-command-to-string`:

```elisp
(let ((got-secret
       (string-trim
        (shell-command-to-string
         (format "%s read op://%s" ...)))))
  (list (list :user user :secret got-secret)))   ; returned unconditionally
```

`shell-command-to-string` discards the process exit status and intermixes
stderr with stdout. So when the reference does not resolve — missing
item/field, wrong vault, `op` locked, not signed in — `op` exits non-zero and
prints `[ERROR] ... could not read secret reference ...` to stderr. That error
text becomes `got-secret`, and the function returns
`(:user USER :secret "<op error message>")`. A missing-but-no-error case
returns `:secret ""`.

## Why it matters

1. **Garbage credentials.** A caller receives the error text (or an empty
   string) as its password instead of failing over to the next backend.
2. **Shadows every other auth-source.** `auth-source-1password-enable` does
   `(add-to-list 'auth-sources '1password)`, which prepends the backend. Since
   it "matches" every host, it sits in front of `~/.authinfo` and friends for
   all lookups, so any host not stored in 1Password (SMTP, IRC, …) also gets a
   bogus secret.

### Reproduce

```elisp
(auth-source-1password-enable)
(auth-source-search :host "does-not-exist.invalid" :user "nobody" :max 1)
;; before: (:user "nobody" :secret "[ERROR] ... could not read ...")
;; after:  nil
```

## The fix

Run `op` via `call-process`, which hands back the exit status, and return
`nil` on a non-zero exit or empty output. stdout and stderr are mixed into one
buffer: on success it holds the secret, on failure `op`'s diagnostics. The
failure output is reported through `auth-source-do-debug`, so it is visible
when `auth-source-debug` is enabled and silent during routine misses:

```elisp
(with-temp-buffer
  (setq status (call-process executable nil t nil
                             "read" (concat "op://" reference))
        output (string-trim (buffer-string))))
(if (and (eq status 0) (not (string= output "")))
    (list (list :user user :secret output))
  (auth-source-do-debug
   "auth-source-1password: `op read op://%s' failed (status %s): %s"
   reference status output)
  nil)
```

Notable details:

- Diagnostics go through `auth-source-do-debug`, not a plain `message`. A
  plain message would flood the echo area: the backend runs `op read` for
  every queried host, so every host kept outside 1Password (SMTP, IRC, …)
  would log an "item not found" error on each lookup. `auth-source-do-debug`
  is gated on the framework's own `auth-source-debug` flag and stays quiet by
  default.
- `shell-quote-argument` is dropped — it was only needed to assemble a shell
  command string. `call-process` passes the reference as a direct argument, so
  quoting it would corrupt the value.
- A `nil` or empty reference (a custom
  `auth-source-1password-construct-secret-reference` opting out of the query)
  skips the `op` call entirely and returns `nil`.
- The "executable not found" path is unchanged (warn + return `nil`).
- Docstring typo fixed: "Searche" → "Search".

## Relationship to #3

This supersedes #3 ("Fix wrong-type-argument on nil secret reference"). That
crash came from passing a `nil` reference to `shell-quote-argument`. Dropping
`shell-quote-argument` here removes the crash outright, and the explicit
`nil`/empty-reference guard preserves #3's intent — a construct that opts out
returns no match — while also avoiding a pointless `op read op://` call.

## Testing

- `check-parens` clean.
- Loaded the file in `emacs --batch`, ran `auth-source-1password-enable`, and
  confirmed a query for a non-resolving host now returns `nil` (previously the
  `op` error text).
- With `auth-source-debug` nil the failed lookup is silent; with it set to `t`
  the `op` error is logged via `auth-source-do-debug`, and the search still
  returns `nil`.
- A `nil` reference returns `nil` with no `wrong-type-argument` (the #3 crash),
  and an empty-string reference returns `nil` as well.
